### PR TITLE
Add initial test suites

### DIFF
--- a/customers/tests.py
+++ b/customers/tests.py
@@ -1,0 +1,9 @@
+from django.test import TestCase
+from utils.tokens import generate_activation_token, verify_activation_token
+
+
+class TokensTest(TestCase):
+    def test_token_roundtrip(self):
+        token = generate_activation_token(1)
+        self.assertEqual(verify_activation_token(token), 1)
+

--- a/customers/tests.py
+++ b/customers/tests.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+
 from utils.tokens import generate_activation_token, verify_activation_token
 
 
@@ -6,4 +7,3 @@ class TokensTest(TestCase):
     def test_token_roundtrip(self):
         token = generate_activation_token(1)
         self.assertEqual(verify_activation_token(token), 1)
-

--- a/pms/tests.py
+++ b/pms/tests.py
@@ -1,1 +1,33 @@
-# Create your tests here.
+from django.test import TestCase
+
+from .models import PMS, PMSDataResponse
+from properties.models import Property
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+
+class PMSTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create(username="owner", password="pass")
+        self.property = Property.objects.create(
+            owner=self.user,
+            name="Prop",
+            description="Desc",
+            address="Addr",
+            location="POINT(0 0)",
+        )
+        self.pms = PMS.objects.create(name="Test PMS")
+
+    def test_pms_str(self):
+        self.assertEqual(str(self.pms), "Test PMS")
+
+    def test_pms_data_response(self):
+        resp = PMSDataResponse.objects.create(
+            pms=self.pms,
+            property=self.property,
+            function_name="f1",
+            response_data={"ok": True},
+        )
+        self.assertIn("ok", resp.response_data)
+

--- a/pms/tests.py
+++ b/pms/tests.py
@@ -1,8 +1,9 @@
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-from .models import PMS, PMSDataResponse
 from properties.models import Property
-from django.contrib.auth import get_user_model
+
+from .models import PMS, PMSDataResponse
 
 User = get_user_model()
 
@@ -30,4 +31,3 @@ class PMSTest(TestCase):
             response_data={"ok": True},
         )
         self.assertIn("ok", resp.response_data)
-

--- a/properties/sync_service.py
+++ b/properties/sync_service.py
@@ -157,7 +157,7 @@ class SyncService:
         return True
 
     @classmethod
-    def sync_reservations(cls, prop: Property, helper, user = None):
+    def sync_reservations(cls, prop: Property, helper, user=None):
         reservations_data = helper.download_reservations(prop)
         if not reservations_data:
             return False

--- a/properties/tests.py
+++ b/properties/tests.py
@@ -1,9 +1,11 @@
-from django.test import TestCase
-from django.contrib.auth import get_user_model
 from datetime import date
 
-from .models import Property, Room, RoomType
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
 from reservations.models import Reservation
+
+from .models import Property, Room, RoomType
 
 User = get_user_model()
 
@@ -19,7 +21,13 @@ class PropertyModelTest(TestCase):
             location="POINT(0 0)",
         )
         self.room_type = RoomType.objects.create(property=self.property, name="Deluxe")
-        self.room = Room.objects.create(property=self.property, type=self.room_type, name="Room 1", description="Desc", pax=2)
+        self.room = Room.objects.create(
+            property=self.property,
+            type=self.room_type,
+            name="Room 1",
+            description="Desc",
+            pax=2,
+        )
 
     def test_property_str(self):
         self.assertEqual(str(self.property), "Test Property")
@@ -30,8 +38,8 @@ class PropertyModelTest(TestCase):
     def test_room_availability(self):
         start = date(2025, 1, 1)
         end = date(2025, 1, 2)
-        Reservation.objects.create(property=self.property, check_in=start, check_out=end)
+        Reservation.objects.create(
+            property=self.property, check_in=start, check_out=end
+        )
         self.room.reservations.add(Reservation.objects.first())
         self.assertFalse(self.room.is_available(start, end))
-
-

--- a/properties/tests.py
+++ b/properties/tests.py
@@ -1,1 +1,37 @@
-# Create your tests here.
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from datetime import date
+
+from .models import Property, Room, RoomType
+from reservations.models import Reservation
+
+User = get_user_model()
+
+
+class PropertyModelTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create(username="owner", password="pass")
+        self.property = Property.objects.create(
+            owner=self.user,
+            name="Test Property",
+            description="Desc",
+            address="Somewhere",
+            location="POINT(0 0)",
+        )
+        self.room_type = RoomType.objects.create(property=self.property, name="Deluxe")
+        self.room = Room.objects.create(property=self.property, type=self.room_type, name="Room 1", description="Desc", pax=2)
+
+    def test_property_str(self):
+        self.assertEqual(str(self.property), "Test Property")
+
+    def test_room_str(self):
+        self.assertEqual(str(self.room), "Room 1 - Test Property")
+
+    def test_room_availability(self):
+        start = date(2025, 1, 1)
+        end = date(2025, 1, 2)
+        Reservation.objects.create(property=self.property, check_in=start, check_out=end)
+        self.room.reservations.add(Reservation.objects.first())
+        self.assertFalse(self.room.is_available(start, end))
+
+

--- a/reservations/tests.py
+++ b/reservations/tests.py
@@ -1,1 +1,61 @@
-# Create your tests here.
+from datetime import date
+from django.test import TestCase
+from django.core.exceptions import ValidationError
+from django.contrib.auth import get_user_model
+
+from properties.models import Property, Room, RoomType
+from .models import Reservation, ReservationRoom
+
+User = get_user_model()
+
+
+class ReservationModelTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create(username="owner", password="pass")
+        self.property = Property.objects.create(
+            owner=self.user,
+            name="Test Property",
+            description="Desc",
+            address="Somewhere",
+            location="POINT(0 0)",
+        )
+        self.room_type = RoomType.objects.create(property=self.property, name="Deluxe")
+        self.room = Room.objects.create(
+            property=self.property,
+            type=self.room_type,
+            name="Room 1",
+            description="Desc",
+            pax=2,
+        )
+
+    def test_reservation_str(self):
+        reservation = Reservation.objects.create(
+            property=self.property,
+            check_in=date(2025, 1, 1),
+            check_out=date(2025, 1, 2),
+        )
+        reservation.rooms.add(self.room)
+        expected = f"Reserva en {self.room.name} del 2025-01-01 al 2025-01-02"
+        self.assertEqual(str(reservation), expected)
+
+    def test_overlapping_reservation_room(self):
+        reservation1 = Reservation.objects.create(
+            property=self.property,
+            check_in=date(2025, 1, 1),
+            check_out=date(2025, 1, 3),
+        )
+        ReservationRoom.objects.create(reservation=reservation1, room=self.room, room_type=self.room_type)
+
+        reservation2 = Reservation.objects.create(
+            property=self.property,
+            check_in=date(2025, 1, 2),
+            check_out=date(2025, 1, 4),
+        )
+        rr = ReservationRoom(
+            reservation=reservation2,
+            room=self.room,
+            room_type=self.room_type,
+        )
+        with self.assertRaises(ValidationError):
+            rr.clean()
+

--- a/reservations/tests.py
+++ b/reservations/tests.py
@@ -1,9 +1,11 @@
 from datetime import date
-from django.test import TestCase
-from django.core.exceptions import ValidationError
+
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.test import TestCase
 
 from properties.models import Property, Room, RoomType
+
 from .models import Reservation, ReservationRoom
 
 User = get_user_model()
@@ -44,7 +46,9 @@ class ReservationModelTest(TestCase):
             check_in=date(2025, 1, 1),
             check_out=date(2025, 1, 3),
         )
-        ReservationRoom.objects.create(reservation=reservation1, room=self.room, room_type=self.room_type)
+        ReservationRoom.objects.create(
+            reservation=reservation1, room=self.room, room_type=self.room_type
+        )
 
         reservation2 = Reservation.objects.create(
             property=self.property,
@@ -58,4 +62,3 @@ class ReservationModelTest(TestCase):
         )
         with self.assertRaises(ValidationError):
             rr.clean()
-

--- a/zones/tests.py
+++ b/zones/tests.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+
 from .models import Zone, ZoneImage
 
 
@@ -12,4 +13,3 @@ class ZoneTest(TestCase):
     def test_zone_image_str(self):
         img = ZoneImage.objects.create(zone=self.zone, image="path/test.jpg")
         self.assertIn(self.zone.name, str(img))
-

--- a/zones/tests.py
+++ b/zones/tests.py
@@ -1,1 +1,15 @@
-# Create your tests here.
+from django.test import TestCase
+from .models import Zone, ZoneImage
+
+
+class ZoneTest(TestCase):
+    def setUp(self):
+        self.zone = Zone.objects.create(name="Zone", description="Desc")
+
+    def test_zone_str(self):
+        self.assertEqual(str(self.zone), "Zone")
+
+    def test_zone_image_str(self):
+        img = ZoneImage.objects.create(zone=self.zone, image="path/test.jpg")
+        self.assertIn(self.zone.name, str(img))
+


### PR DESCRIPTION
## Summary
- add initial tests for properties, reservations, PMS, zones and customer token helpers

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68769be623988329aa391809f24df9e9