### PR TITLE
Add staff dashboard with revenue chart

### DIFF
--- a/templates/admin/properties/property/dashboard.html
+++ b/templates/admin/properties/property/dashboard.html
@@ -1,0 +1,25 @@
+{% extends "admin/base_site.html" %}
+{% load static %}
+
+{% block content %}
+<h1>Dashboard</h1>
+<canvas id="revenueChart" height="100"></canvas>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+const labels = {{ labels|safe }};
+const datasets = [
+    {% for ds in datasets %}
+    {
+        label: "{{ ds.label }}",
+        data: {{ ds.data|safe }},
+        backgroundColor: "{{ ds.color }}"
+    },
+    {% endfor %}
+];
+new Chart(document.getElementById('revenueChart'), {
+    type: 'bar',
+    data: {labels: labels, datasets: datasets},
+    options: {responsive: true, plugins: {legend: {position: 'top'}}}
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- show only owner data to staff users in the admin (already enforced) and add a new dashboard
- new admin view aggregates revenues per property and room type
- display results in a colorful Chart.js bar chart

## Testing
- `python manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6876bbbebef88329ab23b892c93c79bb