### PR TITLE
Implement reservation cancellation flow

### DIFF
--- a/reservations/admin.py
+++ b/reservations/admin.py
@@ -1,15 +1,18 @@
-from django.contrib import admin
+from django.contrib import admin, messages
+from utils.email_service import EmailService
+from utils.error_codes import ReservationError
 
 from .models import Reservation
 
 
 @admin.register(Reservation)
 class ReservationAdmin(admin.ModelAdmin):
-    list_display = ("guest_name", "check_in", "check_out", "created_at")
+    list_display = ("guest_name", "check_in", "check_out", "status", "created_at")
     list_filter = ("check_in", "check_out")
     search_fields = ("guest_name", "guest_email", "reservations__room_type__name")
     exclude = ("user",)
     readonly_fields = ("room_types_reserved",)
+    actions = ["cancel_reservations", "mark_refunded"]
 
     def save_model(self, request, obj, form, change):
         if not change:
@@ -25,5 +28,48 @@ class ReservationAdmin(admin.ModelAdmin):
     def room_types_reserved(self, obj):
         room_types = obj.reservations.select_related("room_type").all()
         return ", ".join(set(rr.room_type.name for rr in room_types if rr.room_type))
+
+    def cancel_reservations(self, request, queryset):
+        for reservation in queryset:
+            try:
+                reservation.cancel()
+            except ReservationError as e:
+                self.message_user(request, str(e), level=messages.ERROR)
+                continue
+
+            if reservation.guest_email:
+                EmailService.send_email(
+                    subject="Cancelación en proceso",
+                    to_email=reservation.guest_email,
+                    template_name="emails/reservation_cancellation_processing.html",
+                    context={"reservation": reservation},
+                )
+
+            owner_email = getattr(reservation.property.owner, "email", None)
+            if owner_email:
+                EmailService.send_email(
+                    subject="Reserva pendiente de devolución",
+                    to_email=owner_email,
+                    template_name="emails/reservation_cancellation_owner_notice.html",
+                    context={"reservation": reservation},
+                )
+
+        self.message_user(request, "Reservas canceladas")
+
+    cancel_reservations.short_description = "Cancelar reservas seleccionadas"
+
+    def mark_refunded(self, request, queryset):
+        updated = 0
+        for reservation in queryset:
+            try:
+                reservation.mark_refunded()
+                updated += 1
+            except ReservationError as e:
+                self.message_user(request, str(e), level=messages.ERROR)
+
+        if updated:
+            self.message_user(request, f"{updated} reservas marcadas como devueltas")
+
+    mark_refunded.short_description = "Marcar como devuelto"
 
     room_types_reserved.short_description = "Tipos de habitación reservados"

--- a/reservations/api.py
+++ b/reservations/api.py
@@ -8,11 +8,13 @@ from django.utils.timezone import now
 from django.views.decorators.csrf import csrf_exempt
 from ninja import Router
 
+from utils.email_service import EmailService
+
 from pms.utils.property_helper_factory import PMSHelperFactory
 from properties.models import Availability, Property
 from properties.sync_service import SyncService
 from utils import ErrorSchema, SuccessSchema
-from utils.error_codes import APIError, ReservationErrorCode
+from utils.error_codes import APIError, ReservationError, ReservationErrorCode
 from utils.redsys import RedsysService
 
 from .models import PaymentNotificationLog, Reservation, ReservationRoom
@@ -177,6 +179,23 @@ def redsys_notification(request):
             reservation.status = Reservation.CONFIRMED
             reservation.save()
 
+            if reservation.guest_email:
+                EmailService.send_email(
+                    subject="Reserva confirmada",
+                    to_email=reservation.guest_email,
+                    template_name="emails/reservation_confirmation_guest.html",
+                    context={"reservation": reservation},
+                )
+
+            owner_email = getattr(reservation.property.owner, "email", None)
+            if owner_email:
+                EmailService.send_email(
+                    subject="Nueva reserva confirmada",
+                    to_email=owner_email,
+                    template_name="emails/reservation_confirmation_owner.html",
+                    context={"reservation": reservation},
+                )
+
             # Notificar al PMS si lo deseas aquí
 
         return SuccessSchema(
@@ -202,3 +221,35 @@ def redsys_notification(request):
 def my_reservations(request):
     reservations = Reservation.objects.filter(user=request.user).order_by("-created_at")
     return reservations
+
+
+@router.post("/{reservation_id}/cancel", response={200: SuccessSchema, 400: ErrorSchema})
+def cancel_reservation(request, reservation_id: int):
+    try:
+        reservation = Reservation.objects.get(id=reservation_id, user=request.user)
+    except Reservation.DoesNotExist:
+        raise APIError("Reservation not found", ReservationErrorCode.NOT_FOUND)
+
+    try:
+        reservation.cancel()
+    except ReservationError as e:
+        raise APIError(str(e), e.code)
+
+    if reservation.guest_email:
+        EmailService.send_email(
+            subject="Cancelación en proceso",
+            to_email=reservation.guest_email,
+            template_name="emails/reservation_cancellation_processing.html",
+            context={"reservation": reservation},
+        )
+
+    owner_email = getattr(reservation.property.owner, "email", None)
+    if owner_email:
+        EmailService.send_email(
+            subject="Reserva pendiente de devolución",
+            to_email=owner_email,
+            template_name="emails/reservation_cancellation_owner_notice.html",
+            context={"reservation": reservation},
+        )
+
+    return SuccessSchema(message="Reserva cancelada")

--- a/reservations/migrations/0007_add_pending_refund_status.py
+++ b/reservations/migrations/0007_add_pending_refund_status.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('reservations', '0006_alter_reservationroom_unique_together'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='reservation',
+            name='status',
+            field=models.CharField(
+                max_length=20,
+                choices=[
+                    ('pending', 'Pending'),
+                    ('confirmed', 'Confirmed'),
+                    ('pending_refund', 'Pending refund'),
+                    ('cancelled', 'Cancelled'),
+                    ('ok', 'Ok'),
+                ],
+                default='pending',
+                verbose_name='Estado',
+            ),
+        ),
+    ]

--- a/reservations/migrations/0008_add_refunded_status.py
+++ b/reservations/migrations/0008_add_refunded_status.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('reservations', '0007_add_pending_refund_status'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='reservation',
+            name='status',
+            field=models.CharField(
+                max_length=20,
+                choices=[
+                    ('pending', 'Pending'),
+                    ('confirmed', 'Confirmed'),
+                    ('pending_refund', 'Pending refund'),
+                    ('cancelled', 'Cancelled'),
+                    ('refunded', 'Refunded'),
+                    ('ok', 'Ok'),
+                ],
+                default='pending',
+                verbose_name='Estado',
+            ),
+        ),
+    ]

--- a/reservations/tests.py
+++ b/reservations/tests.py
@@ -5,11 +5,14 @@ from django.core import mail
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.utils import timezone
+from unittest.mock import patch
 
 from properties.models import Property, Room, RoomType
 from reservations.tasks import send_check_in_reminder
+from reservations.api import redsys_notification, rs
 
 from .models import Reservation, ReservationRoom
+from utils.error_codes import ReservationError
 
 User = get_user_model()
 
@@ -96,3 +99,83 @@ class ReservationReminderTaskTest(TestCase):
         send_check_in_reminder(7)
         self.assertEqual(len(mail.outbox), 1)
         self.assertIn("guest@example.com", mail.outbox[0].to)
+
+
+class ReservationCancellationTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create(username="owner3", password="pass")
+        self.property = Property.objects.create(
+            owner=self.user,
+            name="Prop 3",
+            description="Desc",
+            address="Addr",
+            location="POINT(0 0)",
+        )
+        self.room_type = RoomType.objects.create(property=self.property, name="Suite")
+        self.reservation = Reservation.objects.create(
+            property=self.property,
+            check_in=timezone.localdate() + timezone.timedelta(days=10),
+            check_out=timezone.localdate() + timezone.timedelta(days=12),
+            guest_email="guest@example.com",
+            user=self.user,
+        )
+
+    def test_cancel_reservation_sets_status_and_date(self):
+        self.assertIsNone(self.reservation.cancellation_date)
+        self.reservation.cancel()
+        self.reservation.refresh_from_db()
+        self.assertEqual(self.reservation.status, Reservation.PENDING_REFUND)
+        self.assertIsNotNone(self.reservation.cancellation_date)
+
+    def test_cannot_cancel_used_reservation(self):
+        used = Reservation.objects.create(
+            property=self.property,
+            check_in=timezone.localdate() - timezone.timedelta(days=2),
+            check_out=timezone.localdate() - timezone.timedelta(days=1),
+            user=self.user,
+            status=Reservation.OK,
+        )
+
+        with self.assertRaises(ReservationError):
+            used.cancel()
+
+    def test_mark_refunded_changes_status(self):
+        self.reservation.cancel()
+        self.reservation.mark_refunded()
+        self.reservation.refresh_from_db()
+        self.assertEqual(self.reservation.status, Reservation.REFUNDED)
+
+        with self.assertRaises(ReservationError):
+            self.reservation.mark_refunded()
+
+
+class ReservationConfirmationEmailTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create(username="owner4", email="owner4@example.com", password="pass")
+        self.property = Property.objects.create(
+            owner=self.user,
+            name="Prop 4",
+            description="Desc",
+            address="Addr",
+            location="POINT(0 0)",
+        )
+        self.room_type = RoomType.objects.create(property=self.property, name="Suite")
+        self.reservation = Reservation.objects.create(
+            property=self.property,
+            check_in=timezone.localdate() + timezone.timedelta(days=5),
+            check_out=timezone.localdate() + timezone.timedelta(days=6),
+            guest_email="guest@example.com",
+        )
+        self.reservation.payment_order = "123456"
+        self.reservation.save()
+
+    def test_emails_sent_on_payment_notification(self):
+        mail.outbox = []
+
+        class DummyRequest:
+            POST = {"Ds_MerchantParameters": "mp", "Ds_Signature": "sig"}
+
+        with patch.object(rs, "process_notification", return_value=({}, "123456")):
+            redsys_notification(DummyRequest())
+
+        self.assertEqual(len(mail.outbox), 2)

--- a/templates/emails/reservation_cancellation_owner_notice.html
+++ b/templates/emails/reservation_cancellation_owner_notice.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="es">
+  <body>
+    <h1>Cancelación solicitada</h1>
+    <p>El usuario {{ reservation.guest_name }} solicitó cancelar su reserva en {{ reservation.property.name }}.</p>
+    <p>Por favor revisa el administrador para procesar la devolución.</p>
+  </body>
+</html>

--- a/templates/emails/reservation_cancellation_owner_notice.txt
+++ b/templates/emails/reservation_cancellation_owner_notice.txt
@@ -1,0 +1,2 @@
+El usuario {{ reservation.guest_name }} solicitó cancelar su reserva en {{ reservation.property.name }}.
+Por favor revisa el administrador para procesar la devolución.

--- a/templates/emails/reservation_cancellation_processing.html
+++ b/templates/emails/reservation_cancellation_processing.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="es">
+  <body>
+    <h1>Cancelación en proceso</h1>
+    <p>Hola {{ reservation.guest_name }}!</p>
+    <p>Estamos procesando la cancelación de tu reserva en {{ reservation.property.name }}.</p>
+    <p>En las próximas horas verás el impacto en tu resumen o la devolución del dinero abonado.</p>
+  </body>
+</html>

--- a/templates/emails/reservation_cancellation_processing.txt
+++ b/templates/emails/reservation_cancellation_processing.txt
@@ -1,0 +1,3 @@
+Hola {{ reservation.guest_name }}!
+Estamos procesando la cancelación de tu reserva en {{ reservation.property.name }}.
+En las próximas horas verás el impacto en tu resumen o la devolución del dinero abonado.

--- a/templates/emails/reservation_confirmation_guest.html
+++ b/templates/emails/reservation_confirmation_guest.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="es">
+  <body>
+    <h1>Reserva confirmada</h1>
+    <p>Hola {{ reservation.guest_name }}!</p>
+    <p>Tu reserva en {{ reservation.property.name }} del {{ reservation.check_in }} al {{ reservation.check_out }} ha sido confirmada.</p>
+    <p>Habitaciones reservadas: {{ reservation.get_room_types }}</p>
+  </body>
+</html>

--- a/templates/emails/reservation_confirmation_guest.txt
+++ b/templates/emails/reservation_confirmation_guest.txt
@@ -1,0 +1,3 @@
+Hola {{ reservation.guest_name }}!
+Tu reserva en {{ reservation.property.name }} del {{ reservation.check_in }} al {{ reservation.check_out }} ha sido confirmada.
+Habitaciones reservadas: {{ reservation.get_room_types }}

--- a/templates/emails/reservation_confirmation_owner.html
+++ b/templates/emails/reservation_confirmation_owner.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="es">
+  <body>
+    <h1>Nueva reserva confirmada</h1>
+    <p>Se ha confirmado una nueva reserva en {{ reservation.property.name }}.</p>
+    <p>Huésped: {{ reservation.guest_name }}</p>
+    <p>Fechas: {{ reservation.check_in }} - {{ reservation.check_out }}</p>
+    <p>Habitaciones reservadas: {{ reservation.get_room_types }}</p>
+  </body>
+</html>

--- a/templates/emails/reservation_confirmation_owner.txt
+++ b/templates/emails/reservation_confirmation_owner.txt
@@ -1,0 +1,4 @@
+Se ha confirmado una nueva reserva en {{ reservation.property.name }}.
+Huésped: {{ reservation.guest_name }}
+Fechas: {{ reservation.check_in }} - {{ reservation.check_out }}
+Habitaciones reservadas: {{ reservation.get_room_types }}

--- a/utils/error_codes.py
+++ b/utils/error_codes.py
@@ -23,6 +23,7 @@ class ReservationErrorCode(IntEnum):
     INVALID_DATES = 102
     PAYMENT_FAILED = 103
     NOT_FOUND = 104
+    CANCEL_NOT_ALLOWED = 105
 
 
 class ReservationError(APIError):


### PR DESCRIPTION
## Summary
- add email templates for cancellation processing
- add cancel handling in Reservation model and API
- let admins cancel reservations and notify guest
- support cancellation error code
- cover cancellation with tests
- add pending refund status and validation of used reservations
- support marking refunded and notify property owner
- send confirmation emails to guest and property owner when a reservation is confirmed

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68794c8434e08329b601d5781e0fb061