### PR TITLE
Add property slug endpoint

### DIFF
--- a/properties/api.py
+++ b/properties/api.py
@@ -62,6 +62,13 @@ def get_property(request, property_id: int):
 
 
 @router.get(
+    "/name/{property_name}", response=PropertyOut, throttle=[UserRateThrottle("1/m")]
+)
+def get_property_by_name(request, property_name: str):
+    return PropertyService.get_property_by_name(property_name)
+
+
+@router.get(
     "/{property_id}/rooms", response=List[RoomOut], throttle=[UserRateThrottle("10/m")]
 )
 def get_property_rooms(request, property_id: int):

--- a/properties/services.py
+++ b/properties/services.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from typing import List, Optional
 
 from django.contrib.gis.geos import Point
+from django.utils.text import slugify
 
 from pms.models import PMS
 from pms.utils.property_helper_factory import PMSHelperFactory
@@ -45,6 +46,18 @@ class PropertyService:
         if zona:
             propiedades = propiedades.filter(zone_id=zona)
         return list(propiedades)
+
+    @staticmethod
+    def get_property_by_name(name: str) -> Property:
+        """Retrieve a property by slugified name."""
+        for prop in Property.objects.filter(active=True):
+            if slugify(prop.name) == slugify(name):
+                return prop
+        raise APIError(
+            "Property not found",
+            PropertyErrorCode.PROPERTY_NOT_FOUND,
+            404,
+        )
 
     @staticmethod
     def get_availability(data: AvailabilityRequest) -> AvailabilityResponse:

--- a/properties/tests.py
+++ b/properties/tests.py
@@ -2,6 +2,7 @@ from datetime import date
 
 from django.contrib.auth import get_user_model
 from django.test import Client, TestCase
+from django.utils.text import slugify
 from rest_framework_simplejwt.tokens import AccessToken
 
 from pms.models import PMS
@@ -189,3 +190,11 @@ class PropertyAPITest(TestCase):
             content_type="application/json",
         )
         self.assertEqual(response.status_code, 400)
+
+    def test_get_property_by_name(self):
+        slug = slugify(self.property.name)
+        response = self.client.get(f"/api/properties/name/{slug}")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["id"], self.property.id)
+        self.assertEqual(data["name"], self.property.name)


### PR DESCRIPTION
## Summary
- support property look up by name
- test retrieving property details by name

## Testing
- `black properties/services.py properties/api.py properties/tests.py`
- `isort properties/services.py properties/api.py properties/tests.py`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

-----