### PR TITLE
Include created property id

### DIFF
--- a/properties/api.py
+++ b/properties/api.py
@@ -19,6 +19,7 @@ from .schemas import (
     AvailabilityResponse,
     PmsDataPropertyIn,
     PmsDataPropertyOut,
+    PropertyCreatedOut,
     PropertyImageOut,
     PropertyIn,
     PropertyOut,
@@ -114,9 +115,14 @@ def my_properties(request):
     return Property.objects.filter(owner=request.user)
 
 
-@router.post("/my/", response=PropertyOut, auth=AuthBearer())
+@router.post("/my/", response=PropertyCreatedOut, auth=AuthBearer())
 def create_property(request, data: PropertyIn):
-    return PropertyService.create_property(request.user, data)
+    prop = PropertyService.create_property(request.user, data)
+    return {
+        "id": prop.id,
+        "message": "Property created",
+        "success": True,
+    }
 
 
 @router.put("/my/{property_id}", response=PropertyOut, auth=AuthBearer())

--- a/properties/schemas.py
+++ b/properties/schemas.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 from ninja import Field, Schema
 
-from utils import generate_presigned_url
+from utils import generate_presigned_url, SuccessSchema
 
 
 class PropertySearchInput(Schema):
@@ -193,6 +193,12 @@ class PropertyUpdateIn(Schema):
     zone_id: Optional[int] = None
     pms_id: Optional[int] = None
     use_pms_information: Optional[bool] = None
+
+
+class PropertyCreatedOut(SuccessSchema):
+    """Response schema for a created property."""
+
+    id: int
 
 
 class PropertyImageOut(Schema):

--- a/properties/tests.py
+++ b/properties/tests.py
@@ -93,6 +93,9 @@ class PropertyAPITest(TestCase):
             content_type="application/json",
         )
         self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("id", data)
+        self.assertTrue(Property.objects.filter(id=data["id"]).exists())
         self.assertEqual(Property.objects.count(), 2)
 
     def test_create_property_invalid_zone(self):


### PR DESCRIPTION
## Summary
- add `PropertyCreatedOut` schema to expose the property ID on creation
- return the ID when creating a property through `/my/`
- verify that the ID is present in property creation tests

## Testing
- `pytest properties/tests.py::PropertiesTests::test_create_property -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688b95d83fc48329a1b4d8984365f2bd