### PR TITLE
Improve PMS helper factory

### DIFF
--- a/pms/migrations/0003_pms_pms_key.py
+++ b/pms/migrations/0003_pms_pms_key.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("pms", "0002_pms_pms_external_id_pmsdataresponse"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="pms",
+            name="pms_key",
+            field=models.CharField(max_length=255, unique=True, default="fnsrooms"),
+            preserve_default=False,
+        ),
+    ]
+

--- a/pms/migrations/0004_set_pms_key_default.py
+++ b/pms/migrations/0004_set_pms_key_default.py
@@ -1,0 +1,18 @@
+from django.db import migrations
+
+
+def set_pms_key(apps, schema_editor):
+    PMS = apps.get_model("pms", "PMS")
+    # Ensure existing records have a value for ``pms_key``.
+    PMS.objects.all().update(pms_key="fnsrooms")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("pms", "0003_pms_pms_key"),
+    ]
+
+    operations = [
+        migrations.RunPython(set_pms_key, migrations.RunPython.noop),
+    ]

--- a/pms/models.py
+++ b/pms/models.py
@@ -1,5 +1,6 @@
-from django.db import models
 from django.core.exceptions import ValidationError
+from django.db import models
+
 
 class PMS(models.Model):
     name = models.CharField(max_length=255, unique=True)

--- a/pms/models.py
+++ b/pms/models.py
@@ -1,9 +1,13 @@
 from django.db import models
+from django.core.exceptions import ValidationError
+
+from pms.utils.property_helper_factory import PMSHelperFactory
 
 
 class PMS(models.Model):
     name = models.CharField(max_length=255, unique=True)
     active = models.BooleanField(default=True)
+    pms_key = models.CharField(max_length=255, unique=True)
     pms_external_id = models.CharField(
         max_length=255, unique=True, blank=True, null=True
     )
@@ -11,6 +15,12 @@ class PMS(models.Model):
     description = models.TextField(blank=True, null=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
+
+    def clean(self):
+        super().clean()
+        factory = PMSHelperFactory()
+        if not factory.has_helper(self.pms_key):
+            raise ValidationError({"pms_key": "No helper found for this key."})
 
     def __str__(self):
         return self.name

--- a/pms/models.py
+++ b/pms/models.py
@@ -1,9 +1,6 @@
 from django.db import models
 from django.core.exceptions import ValidationError
 
-from pms.utils.property_helper_factory import PMSHelperFactory
-
-
 class PMS(models.Model):
     name = models.CharField(max_length=255, unique=True)
     active = models.BooleanField(default=True)
@@ -18,6 +15,9 @@ class PMS(models.Model):
 
     def clean(self):
         super().clean()
+        # Import lazily to avoid circular import issues during app loading
+        from pms.utils.property_helper_factory import PMSHelperFactory
+
         factory = PMSHelperFactory()
         if not factory.has_helper(self.pms_key):
             raise ValidationError({"pms_key": "No helper found for this key."})

--- a/pms/tests.py
+++ b/pms/tests.py
@@ -18,7 +18,7 @@ class PMSTest(TestCase):
             address="Addr",
             location="POINT(0 0)",
         )
-        self.pms = PMS.objects.create(name="Test PMS")
+        self.pms = PMS.objects.create(name="Test PMS", pms_key="fnsrooms")
 
     def test_pms_str(self):
         self.assertEqual(str(self.pms), "Test PMS")
@@ -31,3 +31,41 @@ class PMSTest(TestCase):
             response_data={"ok": True},
         )
         self.assertIn("ok", resp.response_data)
+
+
+class PMSHelperFactoryTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create(username="owner2", password="pass")
+        self.pms = PMS.objects.create(name="Factory PMS", pms_key="fnsrooms")
+        self.property = Property.objects.create(
+            owner=self.user,
+            name="Factory Property",
+            description="Desc",
+            address="Addr",
+            location="POINT(0 0)",
+            pms=self.pms,
+        )
+
+    def test_get_helper(self):
+        from pms.utils.helpers.FnsPropertyHelper import FnsPropertyHelper
+        from pms.utils.property_helper_factory import PMSHelperFactory
+
+        factory = PMSHelperFactory()
+        self.assertTrue(factory.has_helper("fnsrooms"))
+        helper = factory.get_helper(self.property)
+        self.assertIsInstance(helper, FnsPropertyHelper)
+
+    def test_get_helper_no_pms(self):
+        from pms.utils.property_helper_factory import PMSHelperFactory
+
+        prop = Property.objects.create(
+            owner=self.user,
+            name="No PMS",
+            description="Desc",
+            address="Addr2",
+            location="POINT(0 0)",
+        )
+
+        factory = PMSHelperFactory()
+        with self.assertRaises(ValueError):
+            factory.get_helper(prop)

--- a/pms/utils/helpers/FnsPropertyHelper.py
+++ b/pms/utils/helpers/FnsPropertyHelper.py
@@ -15,6 +15,10 @@ from properties.models import Property
 class FnsPropertyHelper(BasePropertyHelper):
     """Helper class for FNS Rooms PMS integration."""
 
+    #: Unique key used by :class:`PMSHelperFactory` to register this helper.
+    #: This should match ``PMS.pms_key`` in the database.
+    pms_key = "fnsrooms"
+
     def __init__(self, prop: Property):
         super().__init__(prop)
         self.api_auth = AuthApi()

--- a/pms/utils/property_helper_factory.py
+++ b/pms/utils/property_helper_factory.py
@@ -1,18 +1,49 @@
+"""Utilities to obtain the correct PMS helper for a property."""
+
+from importlib import import_module
+import inspect
+import pkgutil
 from typing import Dict, Type
 
-from pms.utils.helpers import FnsPropertyHelper
+from django.utils.text import slugify
+
+from pms.utils.helpers import __path__ as helpers_path, __name__ as helpers_pkg
 from pms.utils.helpers.base import BasePropertyHelper
 from properties.models import Property
 from utils.SingletonMeta import SingletonMeta
 
 
 class PMSHelperFactory(metaclass=SingletonMeta):
-    _helpers: Dict[int, Type[BasePropertyHelper]] = {
-        1: FnsPropertyHelper,
-    }
+    """Factory that returns the helper class for a given ``Property``."""
+
+    def __init__(self) -> None:
+        self._helpers: Dict[str, Type[BasePropertyHelper]] = {}
+        self._discover_helpers()
+
+    def _discover_helpers(self) -> None:
+        """Populate ``self._helpers`` discovering available helpers."""
+        for _, module_name, ispkg in pkgutil.iter_modules(helpers_path):
+            if ispkg:
+                continue
+            module = import_module(f"{helpers_pkg}.{module_name}")
+            for _, obj in inspect.getmembers(module, inspect.isclass):
+                if (
+                    issubclass(obj, BasePropertyHelper)
+                    and obj is not BasePropertyHelper
+                ):
+                    key = getattr(obj, "pms_key", slugify(obj.__name__))
+                    self._helpers[key] = obj
+
+    def has_helper(self, key: str) -> bool:
+        """Return ``True`` if a helper is registered for ``key``."""
+        return key in self._helpers
 
     def get_helper(self, prop: Property) -> BasePropertyHelper:
-        helper_class = self._helpers.get(prop.pms_id)
+        if prop.pms is None:
+            raise ValueError("Property has no PMS associated")
+
+        key = prop.pms.pms_key or slugify(prop.pms.name)
+        helper_class = self._helpers.get(key)
         if helper_class is None:
-            raise ValueError(f"PMS ID {prop.pms_id} no soportado")
+            raise ValueError(f"PMS '{key}' no soportado")
         return helper_class(prop)

--- a/pms/utils/property_helper_factory.py
+++ b/pms/utils/property_helper_factory.py
@@ -1,13 +1,14 @@
 """Utilities to obtain the correct PMS helper for a property."""
 
-from importlib import import_module
 import inspect
 import pkgutil
+from importlib import import_module
 from typing import Dict, Type
 
 from django.utils.text import slugify
 
-from pms.utils.helpers import __path__ as helpers_path, __name__ as helpers_pkg
+from pms.utils.helpers import __name__ as helpers_pkg
+from pms.utils.helpers import __path__ as helpers_path
 from pms.utils.helpers.base import BasePropertyHelper
 from properties.models import Property
 from utils.SingletonMeta import SingletonMeta

--- a/properties/tests.py
+++ b/properties/tests.py
@@ -17,7 +17,7 @@ User = get_user_model()
 class PropertyModelTest(TestCase):
     def setUp(self):
         self.user = User.objects.create(username="owner", password="pass")
-        self.pms = PMS.objects.create(name="Test PMS")
+        self.pms = PMS.objects.create(name="Test PMS", pms_key="fnsrooms")
         self.property = Property.objects.create(
             owner=self.user,
             name="Test Property",
@@ -59,7 +59,7 @@ class PropertyAPITest(TestCase):
             is_staff=True,
         )
         self.zone = Zone.objects.create(name="Zone", description="desc")
-        self.pms = PMS.objects.create(name="Test PMS")
+        self.pms = PMS.objects.create(name="Test PMS", pms_key="fnsrooms")
         self.property = Property.objects.create(
             owner=self.staff,
             name="APITestProp",


### PR DESCRIPTION
## Summary
- add new `pms_key` field and validation to `PMS` model
- update factory to use `pms_key` and expose helper lookup
- tweak `FnsPropertyHelper` docs
- adjust tests for `pms_key`
- add migration for new field
- set `pms_key` on existing PMS records
- test PMSHelperFactory functionality

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_688bb952888483299daaa083fce3d8a0