### PR TITLE
Add PMS listing endpoint

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -22,6 +22,7 @@ from ninja import NinjaAPI
 from customers.api import customer_router
 from properties.api import router as properties_router
 from reservations.api import router as reservation_router
+from pms.api import router as pms_router
 from utils.auth_bearer import AuthBearer
 from utils.error_codes import APIError
 from utils.schemas import ErrorSchema
@@ -63,6 +64,11 @@ api.add_router(
     "/reservations/",
     reservation_router,
     auth=auth_bearer,
+)
+api.add_router(
+    "/pms/",
+    pms_router,
+    auth=public_auth,
 )
 
 urlpatterns = [

--- a/core/urls.py
+++ b/core/urls.py
@@ -20,9 +20,9 @@ from django.urls import path
 from ninja import NinjaAPI
 
 from customers.api import customer_router
+from pms.api import router as pms_router
 from properties.api import router as properties_router
 from reservations.api import router as reservation_router
-from pms.api import router as pms_router
 from utils.auth_bearer import AuthBearer
 from utils.error_codes import APIError
 from utils.schemas import ErrorSchema

--- a/pms/api.py
+++ b/pms/api.py
@@ -1,0 +1,14 @@
+from typing import List
+
+from ninja import Router
+
+from .models import PMS
+from .schemas import PMSOut
+
+router = Router(tags=["pms"])
+
+
+@router.get("/", response={200: List[PMSOut]})
+def list_pms(request):
+    """Return all PMS with integration enabled"""
+    return list(PMS.objects.filter(active=True, has_integration=True))

--- a/pms/schemas.py
+++ b/pms/schemas.py
@@ -1,0 +1,14 @@
+from typing import Optional
+
+from ninja import Schema
+
+
+class PMSOut(Schema):
+    """Schema for PMS output"""
+
+    id: int
+    name: str
+    pms_key: str
+    pms_external_id: Optional[str] = None
+    has_integration: bool
+    description: Optional[str] = None

--- a/pms/tests.py
+++ b/pms/tests.py
@@ -1,5 +1,5 @@
 from django.contrib.auth import get_user_model
-from django.test import TestCase, Client
+from django.test import TestCase
 
 from properties.models import Property
 
@@ -73,8 +73,9 @@ class PMSHelperFactoryTest(TestCase):
 
 class PMSAPITest(TestCase):
     def setUp(self):
-        self.client = Client()
-        PMS.objects.create(name="Integrated PMS", pms_key="fnsrooms", has_integration=True)
+        PMS.objects.create(
+            name="Integrated PMS", pms_key="fnsrooms", has_integration=True
+        )
         PMS.objects.create(name="Disabled PMS", pms_key="nopms", has_integration=False)
 
     def test_list_pms(self):
@@ -83,4 +84,3 @@ class PMSAPITest(TestCase):
         data = response.json()
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]["name"], "Integrated PMS")
-

--- a/pms/tests.py
+++ b/pms/tests.py
@@ -1,5 +1,5 @@
 from django.contrib.auth import get_user_model
-from django.test import TestCase
+from django.test import TestCase, Client
 
 from properties.models import Property
 
@@ -69,3 +69,18 @@ class PMSHelperFactoryTest(TestCase):
         factory = PMSHelperFactory()
         with self.assertRaises(ValueError):
             factory.get_helper(prop)
+
+
+class PMSAPITest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        PMS.objects.create(name="Integrated PMS", pms_key="fnsrooms", has_integration=True)
+        PMS.objects.create(name="Disabled PMS", pms_key="nopms", has_integration=False)
+
+    def test_list_pms(self):
+        response = self.client.get("/api/pms/", HTTP_X_APP_KEY="clave-larga-y-unica")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["name"], "Integrated PMS")
+


### PR DESCRIPTION
## Summary
- add schema and router for PMS
- expose PMS router in core URL config
- test listing endpoint for integrated PMS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688bf48c59fc8329b8cfcbf0aac6ed60