### PR TITLE
Add endpoint to update RoomType for staff

### DIFF
--- a/properties/api.py
+++ b/properties/api.py
@@ -25,6 +25,7 @@ from .schemas import (
     PropertyUpdateIn,
     RoomTypeImageOut,
     RoomTypeOut,
+    RoomTypeUpdateIn,
 )
 from .services import PropertyService
 
@@ -201,6 +202,16 @@ def list_room_type_images(request, room_type_id: int):
 )
 def add_room_type_image(request, room_type_id: int, image: UploadedFile = File(...)):
     return PropertyService.add_room_type_image(request.user, room_type_id, image)
+
+
+@router.put(
+    "/my/room-types/{room_type_id}",
+    response=RoomTypeOut,
+    auth=AuthBearer(),
+)
+def update_room_type(request, room_type_id: int, data: RoomTypeUpdateIn):
+    """Update a room type for the authenticated staff user."""
+    return PropertyService.update_room_type(request.user, room_type_id, data)
 
 
 @router.post(

--- a/properties/schemas.py
+++ b/properties/schemas.py
@@ -195,6 +195,13 @@ class PropertyUpdateIn(Schema):
     use_pms_information: Optional[bool] = None
 
 
+class RoomTypeUpdateIn(Schema):
+    """Input schema for updating a room type."""
+
+    name: Optional[str] = None
+    description: Optional[str] = None
+
+
 class PropertyImageOut(Schema):
     id: int
     image: str


### PR DESCRIPTION
## Summary
- allow staff to update room type name and description
- expose new `RoomTypeUpdateIn` schema
- add service and API endpoint to update room types
- cover new behaviour with tests

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_688ce3ee18e48329a343a7885cee136a