### PR TITLE
refactor: remove rooms in favor of room types

### DIFF
--- a/ERROR_CODES.md
+++ b/ERROR_CODES.md
@@ -24,7 +24,7 @@ The frontend can map these codes to custom messages for the user.
 |203|Could not parse rates|
 |204|No price found for requested guests|
 |205|No availability for the selected dates|
-|206|Room not found|
+|206|Room type not found|
 |207|Zone ID or Property ID is required|
 
 ## Customer Errors (300-399)

--- a/core/settings.py
+++ b/core/settings.py
@@ -200,7 +200,6 @@ JAZZMIN_SETTINGS = {
         "zones.Zone": "fas fa-map-marked-alt",
         "properties.Property": "fas fa-building",
         "reservations.Reservartion": "fas fa-calendar-check",
-        "properties.Room": "fas fa-door-open",
         "properties.CommunicationMethod": "fas fa-comment-dots",
         "properties.Service": "fas fa-concierge-bell",
         "vouchers.Voucher": "fas fa-ticket-alt",

--- a/properties/admin.py
+++ b/properties/admin.py
@@ -11,13 +11,11 @@ from properties.admin_utils.inlines import (
     CommunicationMethodInline,
     PMSDataInline,
     PropertyImageInline,
-    RoomImageInline,
-    RoomInline,
     RoomTypeImageInline,
     RoomTypeInline,
     TermsAndConditionsInline,
 )
-from properties.models import CommunicationMethod, Property, Room, RoomType, Service
+from properties.models import CommunicationMethod, Property, RoomType, Service
 
 from .sync_service import SyncService
 
@@ -35,7 +33,7 @@ class PropertyAdmin(GISModelAdmin):
         CommunicationMethodInline,
         TermsAndConditionsInline,
     ]  # add "current_reservations"
-    search_fields = ["name", "location", "rooms__pax"]
+    search_fields = ["name", "location", "room_types__name"]
     list_display = (
         "name",
         "cover_preview",
@@ -210,20 +208,6 @@ class PropertyAdmin(GISModelAdmin):
             )
             return False
 
-        sync_rooms = SyncService.sync_rooms(prop, helper)
-        if sync_rooms:
-            self.message_user(
-                request,
-                f"Habitaciones de la propiedad {prop.name} actualizadas correctamente.",
-                level=messages.SUCCESS,
-            )
-        else:
-            self.message_user(
-                request,
-                f"No se encontraron habitaciones para la propiedad {prop.name}.",
-                level=messages.ERROR,
-            )
-
         sync_reservations = SyncService.sync_reservations(prop, helper, request.user)
         if sync_reservations:
             self.message_user(
@@ -344,20 +328,6 @@ class PropertyAdmin(GISModelAdmin):
         )
 
 
-@admin.register(Room)
-class RoomAdmin(admin.ModelAdmin):
-    inlines = [RoomImageInline]  # ReservationInline
-    list_display = ("name", "property", "pax")
-
-    def get_queryset(self, request):
-        qs = super().get_queryset(request)
-        if request.user.is_superuser:
-            return qs
-        if request.user.is_staff:
-            return qs.filter(property__owner=request.user)
-        return qs.none()
-
-
 @admin.register(Service)
 class ServiceAdmin(admin.ModelAdmin):
     list_display = ("name",)
@@ -387,12 +357,12 @@ class CommunicationMethodAdmin(admin.ModelAdmin):
 @admin.register(RoomType)
 class RoomTypeAdmin(admin.ModelAdmin):
     list_display = ("name",)
-    inlines = [RoomInline, RoomTypeImageInline]
+    inlines = [RoomTypeImageInline]
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
         if request.user.is_superuser:
             return qs
         if request.user.is_staff:
-            return qs.filter(rooms__property__owner=request.user)
+            return qs.filter(property__owner=request.user)
         return qs.none()

--- a/properties/admin_utils/inlines.py
+++ b/properties/admin_utils/inlines.py
@@ -4,23 +4,10 @@ from properties.models import (
     CommunicationMethod,
     PmsDataProperty,
     PropertyImage,
-    Room,
-    RoomImage,
     RoomType,
     RoomTypeImage,
     TermsAndConditions,
 )
-
-
-class RoomImageInline(admin.TabularInline):
-    model = RoomImage
-    extra = 1
-
-
-class RoomInline(admin.StackedInline):
-    model = Room
-    extra = 1
-    show_change_link = True
 
 
 class TermsAndConditionsInline(admin.StackedInline):

--- a/properties/migrations/0011_remove_room_models.py
+++ b/properties/migrations/0011_remove_room_models.py
@@ -1,0 +1,12 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("properties", "0010_alter_room_description"),
+    ]
+
+    operations = [
+        migrations.DeleteModel(name="RoomImage"),
+        migrations.DeleteModel(name="Room"),
+    ]

--- a/properties/models.py
+++ b/properties/models.py
@@ -95,6 +95,11 @@ def property_image_upload_path(instance, filename):
     return f"properties/gallery/{uuid4()}-{filename}"
 
 
+# NOTE: Kept for backward compatibility with historical migrations.
+def room_image_upload_path(instance, filename):
+    return f"properties/gallery/{uuid4()}-{filename}"
+
+
 class PropertyImage(models.Model):
     property = models.ForeignKey(
         Property, related_name="gallery", on_delete=models.CASCADE, verbose_name="Zona"

--- a/properties/schemas.py
+++ b/properties/schemas.py
@@ -31,6 +31,17 @@ class AvailabilityOut(Schema):
     rates: List[Rate]
 
 
+class ServiceIn(Schema):
+    name: str
+    description: Optional[str] = None
+
+
+class ServiceOut(Schema):
+    id: int
+    name: str
+    description: Optional[str] = None
+
+
 class RoomTypeOut(Schema):
     id: int
     name: str
@@ -47,36 +58,6 @@ class RoomTypeOut(Schema):
             if obj.images
             else []
         )
-
-
-class RoomOut(Schema):
-    id: int
-    name: str
-    description: str
-    pax: int
-    services: List[str]
-    images: Optional[List[str]]
-    property_id: int
-    type: str
-
-    @staticmethod
-    def resolve_services(obj):
-        return [service.name for service in obj.services.all()] if obj.services else []
-
-    @staticmethod
-    def resolve_images(obj):
-        return (
-            [
-                generate_presigned_url(room_image.image.name)
-                for room_image in obj.images.all()
-            ]
-            if obj.images
-            else []
-        )
-
-    @staticmethod
-    def resolve_type(obj):
-        return obj.type.name if obj.type else None
 
 
 class TermsAndConditionsOut(Schema):
@@ -100,6 +81,7 @@ class PropertyOut(Schema):
     cover_image: Optional[str]
     images: Optional[List[str]]
     room_types: Optional[List[RoomTypeOut]]
+    services: Optional[List[ServiceOut]]
     communication_methods: Optional[List[str]]
     location: Optional[str]
     terms_and_conditions: Optional[TermsAndConditionsOut] = None
@@ -143,11 +125,11 @@ class PropertyOut(Schema):
 
     @staticmethod
     def resolve_room_types(obj):
-        room_types = set()
-        for room in obj.rooms.all():
-            if room.type:
-                room_types.add(room.type)
-        return list(room_types) if room_types else None
+        return obj.room_types.all()
+
+    @staticmethod
+    def resolve_services(obj):
+        return obj.services.all()
 
 
 class RoomAvailability(Schema):

--- a/properties/tests.py
+++ b/properties/tests.py
@@ -9,7 +9,7 @@ from pms.models import PMS
 from reservations.models import Reservation
 from zones.models import Zone
 
-from .models import Property, Room, RoomType
+from .models import Property, RoomType
 
 User = get_user_model()
 
@@ -27,28 +27,10 @@ class PropertyModelTest(TestCase):
             pms=self.pms,
         )
         self.room_type = RoomType.objects.create(property=self.property, name="Deluxe")
-        self.room = Room.objects.create(
-            property=self.property,
-            type=self.room_type,
-            name="Room 1",
-            description="Desc",
-            pax=2,
-        )
 
     def test_property_str(self):
         self.assertEqual(str(self.property), "Test Property")
 
-    def test_room_str(self):
-        self.assertEqual(str(self.room), "Room 1 - Test Property")
-
-    def test_room_availability(self):
-        start = date(2025, 1, 1)
-        end = date(2025, 1, 2)
-        Reservation.objects.create(
-            property=self.property, check_in=start, check_out=end
-        )
-        self.room.reservations.add(Reservation.objects.first())
-        self.assertFalse(self.room.is_available(start, end))
 
 
 class PropertyAPITest(TestCase):

--- a/reservations/admin.py
+++ b/reservations/admin.py
@@ -10,7 +10,11 @@ from .models import Reservation
 class ReservationAdmin(admin.ModelAdmin):
     list_display = ("guest_name", "check_in", "check_out", "status", "created_at")
     list_filter = ("check_in", "check_out")
-    search_fields = ("guest_name", "guest_email", "reservations__room_type__name")
+    search_fields = (
+        "guest_name",
+        "guest_email",
+        "reservation_rooms__room_type__name",
+    )
     exclude = ("user",)
     readonly_fields = ("room_types_reserved",)
     actions = ["cancel_reservations", "mark_refunded"]
@@ -27,8 +31,8 @@ class ReservationAdmin(admin.ModelAdmin):
         return qs.filter(user=request.user)
 
     def room_types_reserved(self, obj):
-        room_types = obj.reservations.select_related("room_type").all()
-        return ", ".join(set(rr.room_type.name for rr in room_types if rr.room_type))
+        room_types = obj.reservation_rooms.select_related("room_type").all()
+        return ", ".join({rr.room_type.name for rr in room_types if rr.room_type})
 
     def cancel_reservations(self, request, queryset):
         for reservation in queryset:

--- a/reservations/migrations/0003_remove_room_fields.py
+++ b/reservations/migrations/0003_remove_room_fields.py
@@ -1,0 +1,36 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("reservations", "0002_alter_reservation_unique_together_and_more"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="reservationroom",
+            name="room",
+        ),
+        migrations.AlterField(
+            model_name="reservationroom",
+            name="reservation",
+            field=models.ForeignKey(
+                on_delete=models.CASCADE,
+                related_name="reservation_rooms",
+                to="reservations.reservation",
+            ),
+        ),
+        migrations.RemoveField(
+            model_name="reservation",
+            name="rooms",
+        ),
+        migrations.AddField(
+            model_name="reservation",
+            name="room_types",
+            field=models.ManyToManyField(
+                related_name="reservations",
+                through="reservations.ReservationRoom",
+                to="properties.roomtype",
+            ),
+        ),
+    ]

--- a/reservations/schemas.py
+++ b/reservations/schemas.py
@@ -93,7 +93,7 @@ class ReservationClientOut(Schema):
                 "price": rr.price,
                 "guests": rr.guests,
             }
-            for rr in obj.reservations.all()
+            for rr in obj.reservation_rooms.all()
         ]
 
     @staticmethod

--- a/reservations/tasks.py
+++ b/reservations/tasks.py
@@ -17,7 +17,7 @@ def send_check_in_reminder(days_before: int):
         guest_email__isnull=False,
     )
     for reservation in reservations:
-        rooms = reservation.rooms.all()
+        room_types = reservation.room_types.all()
         EmailService.send_email(
             subject="Recordatorio de reserva",
             to_email=reservation.guest_email,
@@ -25,7 +25,7 @@ def send_check_in_reminder(days_before: int):
             context={
                 "reservation": reservation,
                 "property": reservation.property,
-                "rooms": rooms,
+                "room_types": room_types,
                 "days_before": days_before,
             },
         )

--- a/utils/error_codes.py
+++ b/utils/error_codes.py
@@ -44,8 +44,9 @@ class PropertyErrorCode(IntEnum):
     RATES_PARSE_ERROR = 203
     PRICE_NOT_FOUND = 204
     NO_AVAILABILITY = 205
-    ROOM_NOT_FOUND = 206
+    ROOM_TYPE_NOT_FOUND = 206
     ZONE_OR_PROPERTY_REQUIRED = 207
+    SERVICE_NOT_FOUND = 208
 
 
 class CustomerErrorCode(IntEnum):


### PR DESCRIPTION
## Summary
- drop room model and related endpoints, relying solely on room types
- expose property-scoped services in property responses
- migrate reservations to store room types instead of rooms
- sync PMS room types without creating room records and return invalid credential errors during sync

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement amqp==5.3.1)*
- `pre-commit run --files properties/sync_service.py properties/services.py` *(fails: command not found: pre-commit)*
- `python manage.py makemigrations` *(fails: No module named 'django')*
- `python manage.py test` *(fails: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68938f5182848329953b83cd4fcf6fed