### PR TITLE
Use bulk upsert for availability sync to avoid duplicates

### DIFF
--- a/properties/sync_service.py
+++ b/properties/sync_service.py
@@ -30,7 +30,7 @@ class SyncService:
                 print(f"Room type not found: {rate_data['room_type']}")
                 continue
 
-            date_obj = datetime.strptime(rate_data["date"], "%Y-%m-%d")
+            date_obj = datetime.strptime(rate_data["date"], "%Y-%m-%d").date()
 
             availability = Availability.objects.filter(
                 property=prop,
@@ -67,7 +67,12 @@ class SyncService:
             )
 
         if availabilities_to_create:
-            Availability.objects.bulk_create(availabilities_to_create)
+            Availability.objects.bulk_create(
+                availabilities_to_create,
+                update_conflicts=True,
+                unique_fields=["property", "room_type", "date"],
+                update_fields=["rates", "availability"],
+            )
 
         return True
 


### PR DESCRIPTION
## Summary
- Convert availability date strings to date objects
- Upsert availability records using `bulk_create(update_conflicts=True)` to prevent unique constraint errors

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install Django==5.2.1` *(fails: Could not find a version that satisfies the requirement Django==5.2.1)*

------
https://chatgpt.com/codex/tasks/task_e_6893e1787fc48329a6b1318a420b7021