### PR TITLE
feat: use local storage in development

### DIFF
--- a/core/settings/development.py
+++ b/core/settings/development.py
@@ -8,3 +8,8 @@ load_dotenv(BASE_DIR / ".env.dev")
 DEBUG = True
 ALLOWED_HOSTS = ["*"]
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+
+# Use local storage for media files during development
+DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
+MEDIA_URL = "/media/"
+MEDIA_ROOT = BASE_DIR / "media"

--- a/properties/models.py
+++ b/properties/models.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 from django.contrib.auth import get_user_model
 from django.contrib.gis.db import models as geomodels
 from django.db import models
-from storages.backends.s3boto3 import S3Boto3Storage
+from utils import get_storage
 
 UserModel = get_user_model()
 
@@ -68,7 +68,7 @@ class Property(models.Model):
         null=True,
         blank=True,
         verbose_name="Imagen",
-        storage=S3Boto3Storage(),
+        storage=get_storage(),
     )
     zone = models.ForeignKey(
         "zones.Zone",
@@ -122,7 +122,7 @@ class PropertyImage(models.Model):
     image = models.ImageField(
         upload_to=property_image_upload_path,
         verbose_name="Imagen",
-        storage=S3Boto3Storage(),
+        storage=get_storage(),
     )
     caption = models.CharField(max_length=255, blank=True, verbose_name="Descripción")
 
@@ -155,7 +155,7 @@ class RoomType(models.Model):
         null=True,
         blank=True,
         verbose_name="Imagen de Portada",
-        storage=S3Boto3Storage(),
+        storage=get_storage(),
     )
 
     class Meta:
@@ -184,7 +184,7 @@ class RoomTypeImage(models.Model):
     image = models.ImageField(
         upload_to=property_image_upload_path,
         verbose_name="Imagen",
-        storage=S3Boto3Storage(),
+        storage=get_storage(),
     )
 
     class Meta:
@@ -239,7 +239,7 @@ def room_image_upload_path(instance, filename):
 class RoomImage(models.Model):
     room = models.ForeignKey(Room, related_name="images", on_delete=models.CASCADE)
     image = models.ImageField(
-        upload_to=room_image_upload_path, storage=S3Boto3Storage()
+        upload_to=room_image_upload_path, storage=get_storage()
     )
 
     class Meta:

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -12,11 +12,13 @@ from .s3_utils import generate_presigned_url
 from .schemas import ErrorSchema, SuccessSchema
 from .SingletonMeta import SingletonMeta
 from .text_utils import extract_pax
+from .storage import get_storage
 
 __all__ = [
     "SingletonMeta",
     "extract_pax",
     "generate_presigned_url",
+    "get_storage",
     "get_ddate_id",
     "get_ddate_text",
     "ErrorSchema",

--- a/utils/storage.py
+++ b/utils/storage.py
@@ -1,0 +1,12 @@
+from django.conf import settings
+from django.core.files.storage import FileSystemStorage
+from storages.backends.s3boto3 import S3Boto3Storage
+
+
+def get_storage():
+    """Return appropriate storage backend depending on environment.
+
+    Uses local filesystem storage when DEBUG is True and S3 storage in
+    production. This avoids unnecessary S3 requests during development.
+    """
+    return FileSystemStorage() if settings.DEBUG else S3Boto3Storage()

--- a/zones/models.py
+++ b/zones/models.py
@@ -2,7 +2,7 @@ from uuid import uuid4
 
 from django.contrib.gis.db import models as geomodels
 from django.db import models
-from storages.backends.s3boto3 import S3Boto3Storage
+from utils import get_storage
 
 
 def zone_cover_image_upload_path(instance, filename):
@@ -20,7 +20,7 @@ class Zone(models.Model):
         null=True,
         blank=True,
         verbose_name="Imagen",
-        storage=S3Boto3Storage(),
+        storage=get_storage(),
     )
 
     class Meta:
@@ -43,7 +43,7 @@ class ZoneImage(models.Model):
     image = models.ImageField(
         upload_to=zone_image_upload_path,
         verbose_name="Imagen",
-        storage=S3Boto3Storage(),
+        storage=get_storage(),
     )
     caption = models.CharField(max_length=255, blank=True, verbose_name="Descripción")
 


### PR DESCRIPTION
## Summary
- switch image uploads to local storage when DEBUG is enabled
- centralize storage selection in new `get_storage` helper
- configure development settings for filesystem-based media

## Testing
- `python manage.py test` *(fails: No module named 'django')*
- `pip install Django==5.2.1` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68941b2104448329bc6b5e4519d69871